### PR TITLE
Minor Fix: Broken Tutorials directory link in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ This installation was tested for python version 3.7 and 3.8
 
 ## Tutorials
 
-Two tutorials are available in the [tutorials](https://github.com/davidruegamer/PySDDR/tree/dev/tutorials) directory. One is aimed as a beginner's guide, where toy data is used to familiarize the user with the package and the second includes a more advanced tutorial with an example of applying the package also to unstructured data.
+Two tutorials are available in the [tutorials](./tutorials) directory. One is aimed as a beginner's guide, where toy data is used to familiarize the user with the package and the second includes a more advanced tutorial with an example of applying the package also to unstructured data.
 
 ## Contents
 


### PR DESCRIPTION
Hi,

Neat project!  While exploring, I found that the link to the tutorials directory in the readme didn't work.  Here's a minor change proposal; this change links to the local tutorials directory instead of the (broken? private?) davidruegamer/dev repo's tutorials directory.  

Best wishes,

Nick